### PR TITLE
fix(sofa-checkout-service): model copy

### DIFF
--- a/src/sofa.checkoutService.js
+++ b/src/sofa.checkoutService.js
@@ -54,7 +54,7 @@ sofa.define('sofa.CheckoutService', function ($http, $q, basketService, loggingS
         var modelCopy = sofa.Util.clone(checkoutModel);
 
         if (modelCopy.addressEqual) {
-            modelCopy.shippingAddress = modelCopy.billingAddress;
+            modelCopy.shippingAddress = sofa.Util.clone(modelCopy.billingAddress);
         }
 
         var requestModel = {};
@@ -78,14 +78,14 @@ sofa.define('sofa.CheckoutService', function ($http, $q, basketService, loggingS
         convertBirthDay(modelCopy.shippingAddress);
 
         if (modelCopy.billingAddress && modelCopy.billingAddress.country) {
-            modelCopy.billingAddress.country = checkoutModel.billingAddress.country.value;
-            modelCopy.billingAddress.countryLabel = checkoutModel.billingAddress.country.label;
+            modelCopy.billingAddress.countryLabel = modelCopy.billingAddress.country.label;
+            modelCopy.billingAddress.country = modelCopy.billingAddress.country.value;
             requestModel.invoiceAddress = JSON.stringify(modelCopy.billingAddress);
         }
 
         if (modelCopy.shippingAddress && modelCopy.shippingAddress.country) {
-            modelCopy.shippingAddress.country = checkoutModel.shippingAddress.country.value;
-            modelCopy.shippingAddress.countryLabel = checkoutModel.shippingAddress.country.label;
+            modelCopy.shippingAddress.countryLabel = modelCopy.shippingAddress.country.label;
+            modelCopy.shippingAddress.country = modelCopy.shippingAddress.country.value;
             requestModel.shippingAddress = JSON.stringify(modelCopy.shippingAddress);
         }
 


### PR DESCRIPTION
- model copy got its values for country from the original checkout model, which broke in case of equal addresses.
- the reassignment of country fields now works due to making a copy of the billing address and preventing override of the country property.
