### PR TITLE
fix(sofa-checkout-service): Changed wrong paramater

### DIFF
--- a/dist/sofa.checkoutService.js
+++ b/dist/sofa.checkoutService.js
@@ -345,7 +345,7 @@ sofa.define('sofa.checkoutservice.CheckoutMethodsRequestConverter', function () 
         }
 
         setIfDefinedAndNotNull(requestModel, 'currency', checkoutModel.currency);
-        setIfDefinedAndNotNull(requestModel, 'payment', checkoutModel.payment);
+        setIfDefinedAndNotNull(requestModel, 'payment', checkoutModel.selectedPaymentMethod);
         setIfDefinedAndNotNull(requestModel, 'shipping', checkoutModel.selectedShippingMethod);
         setIfDefinedAndNotNull(requestModel, 'items', items);
         setIfDefinedAndNotNull(requestModel, 'discounts', checkoutModel.discounts || []);


### PR DESCRIPTION
The parameter checkoutModel.payment seems to be null during checkout, checkoutModel.selectedPaymentMethod is filled
